### PR TITLE
Add spreadsheet url

### DIFF
--- a/src/Spreadheet.php
+++ b/src/Spreadheet.php
@@ -69,6 +69,18 @@ class Spreadsheet implements SpreadsheetInterface
     }
 
     /**
+     * Get the spreadsheet url.
+     *
+     * @return string|null
+     */
+    public function getSpreadsheetUrl() : ?string
+    {
+        if ($this->getSpreadsheetId()) {
+            return sprintf('https://docs.google.com/spreadsheets/d/%s/edit', $this->getSpreadsheetId());
+        }
+    }
+
+    /**
      * Create a Google Sheet.
      *
      * @return \BaseCardHero\Spreadsheet\SpreadsheetInterface

--- a/src/SpreadsheetInterface.php
+++ b/src/SpreadsheetInterface.php
@@ -35,6 +35,13 @@ interface SpreadsheetInterface
     public function getSpreadsheetId() : ?string;
 
     /**
+     * Get the spreadsheet url.
+     *
+     * @return string|null
+     */
+    public function getSpreadsheetUrl() : ?string;
+
+    /**
      * Create a spreadsheet and set the spreadsheet instance.
      *
      * @return \BaseCardHero\Spreadsheet\SpreadsheetInterface

--- a/tests/SpreadsheetTest.php
+++ b/tests/SpreadsheetTest.php
@@ -64,15 +64,31 @@ class SpreadsheetTest extends TestCase
         $this->assertEquals($spreadsheet->getSpreadsheetId(), $this->spreadsheet->getSpreadsheetId());
     }
 
+    /** @test */
     public function getSpreadsheetId_will_return_the_spreadsheet_id()
     {
-        $this->spreadsheet = $this->partial(Spreadsheet::class, [$this->service]);
+        $spreadsheet = $this->createSpreadsheet();
 
+        $this->spreadsheet = $this->partial(Spreadsheet::class, [$this->service]);
         $this->assertNull($this->spreadsheet->getSpreadsheetId());
 
         $this->spreadsheet->setSpreadsheet($spreadsheet);
+        $this->assertEquals($spreadsheet->getSpreadsheetId(), $this->spreadsheet->getSpreadsheetId());
+    }
 
-        $this->assertEquals($spreadsheet, $this->spreadsheet->getSpreadsheet());
+    /** @test */
+    public function getSpreadsheetUrl_will_return_the_spreadsheet_url()
+    {
+        $spreadsheet = $this->createSpreadsheet();
+
+        $this->spreadsheet = $this->partial(Spreadsheet::class, [$this->service]);
+        $this->assertNull($this->spreadsheet->getSpreadsheetId());
+
+        $this->spreadsheet->setSpreadsheet($spreadsheet);
+        $this->assertEquals(
+            sprintf('https://docs.google.com/spreadsheets/d/%s/edit', $spreadsheet->getSpreadsheetId()),
+            $this->spreadsheet->getSpreadsheetUrl()
+        );
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,22 +8,6 @@ use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 class TestCase extends PHPUnitTestCase
 {
     /**
-     * Override parent::tearDown().
-     *
-     * @see https://github.com/GrahamCampbell/Laravel-TestBench/blob/v1.1.2/src/Traits/HelperTestCaseTrait.php#L57
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        if ($container = Mockery::getContainer()) {
-            $this->addToAssertionCount($container->mockery_getExpectationCount());
-        }
-
-        Mockery::close();
-    }
-
-    /**
      * Create a Google_Service_Sheets_Spreadsheet instance.
      *
      * @param string $spreadsheetId Optional spreadsheet id.


### PR DESCRIPTION
Added the ability to retrieve the spreadsheet url.

- Added method `getSpreadsheetUrl()`

Also removed `tearDown()` from `BaseCardHero\Spreadsheet\Tests\TestCase`. It was no longer needed.